### PR TITLE
Habit Tracker: Add new habits to top of list.

### DIFF
--- a/Habit Tracker/src/context/HabitContext.js
+++ b/Habit Tracker/src/context/HabitContext.js
@@ -27,7 +27,7 @@ export const HabitProvider = ({ children }) => {
     const addHabit = (name) => {
         const newHabit = { id: Date.now(), name, completed: false };
         setHabits(prev => {
-            const updatedHabits = [...prev, newHabit];
+            const updatedHabits = [newHabit, ...prev];
             setLocalStorage('habits', updatedHabits);
             return updatedHabits;
         });


### PR DESCRIPTION
fixes #37 

Fixed the issue were new habits were being added to the end of the list.
Now when a new habit is added, it's added to the top of the habit list.

https://github.com/user-attachments/assets/20b910ca-0682-4e4a-aaea-f209b3d3310c

@AakxSha 