### PR TITLE
Enable drag-and-drop task rescheduling in calendar

### DIFF
--- a/Planora/app/calendar/page.tsx
+++ b/Planora/app/calendar/page.tsx
@@ -41,6 +41,7 @@ export default function Calendar() {
   const [newUpdateNote, setNewUpdateNote] = useState('');
   const [newUpdateProgress, setNewUpdateProgress] = useState(0);
   const [newUpdateTimeSpent, setNewUpdateTimeSpent] = useState(30);
+  const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
 
   useEffect(() => {
     const savedTasks = localStorage.getItem('studyTasks');
@@ -144,6 +145,20 @@ export default function Calendar() {
     setShowModal(true);
   };
 
+  const handleTaskDrop = (dateString: string) => {
+  if (!draggedTaskId) return;
+
+  const updatedTasks = tasks.map(task =>
+    task.id === draggedTaskId
+      ? { ...task, dueDate: dateString }
+      : task
+  );
+
+  setTasks(updatedTasks);
+  localStorage.setItem('studyTasks', JSON.stringify(updatedTasks));
+  setDraggedTaskId(null);
+  };
+
   const handleAddUpdate = () => {
     if (!selectedTaskId || !selectedDate || !newUpdateNote.trim()) return;
 
@@ -218,10 +233,16 @@ const TaskBlock = ({
   onClick: () => void;
 }) => (
   <button
+    draggable
+    onDragStart={(e) => {
+      e.stopPropagation();
+      setDraggedTaskId(task.id);
+    }}
     onClick={(e) => {
       e.stopPropagation();
       onClick();
     }}
+
     className={`w-full text-left px-2 py-1 rounded-md text-xs font-medium truncate
       ${
         task.priority === 'high'
@@ -344,9 +365,11 @@ const TaskBlock = ({
 
               return (
                 <div
-                  key={index}
-                  onClick={() => handleDotClick(dayInfo.dateString)}
-                  className={`
+                key={index}
+                onClick={() => handleDotClick(dayInfo.dateString)}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={() => handleTaskDrop(dayInfo.dateString)}
+                className={`
 
                     relative min-h-32 p-2 rounded-xl border-2 transition-all
                     ${dayInfo.isCurrentMonth 


### PR DESCRIPTION
Closes #49

Adds native drag-and-drop support to calendar tasks.
Users can drag tasks between dates to reschedule them instantly.
Changes are minimal and persist updates to localStorage.

**Demo Video:**

https://github.com/user-attachments/assets/a3e99e64-099a-4cb2-8e61-4a73f8b285a0

