### PR TITLE
ISSUE #52 | Created study analytics dashboard

### DIFF
--- a/Planora/app/analytics/page.tsx
+++ b/Planora/app/analytics/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Bar, Line } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+
+import {
+  getDailyStudyTime,
+  getPomodoroCount,
+  getStudyStreak,
+  getMostProductiveHours,
+  getTaskCompletionStats,
+} from "../lib/analytics";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend
+);
+
+/* ---------- shared chart styling ---------- */
+const darkChartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      labels: {
+        color: "#9CA3AF", // gray-400
+        font: { size: 12 },
+      },
+    },
+    tooltip: {
+      backgroundColor: "#111827", // gray-900
+      titleColor: "#E5E7EB",
+      bodyColor: "#D1D5DB",
+      borderColor: "#374151",
+      borderWidth: 1,
+    },
+  },
+  scales: {
+    x: {
+      grid: {
+        color: "rgba(255,255,255,0.05)",
+      },
+      ticks: {
+        color: "#9CA3AF",
+      },
+    },
+    y: {
+      grid: {
+        color: "rgba(255,255,255,0.05)",
+      },
+      ticks: {
+        color: "#9CA3AF",
+      },
+    },
+  },
+};
+
+export default function AnalyticsPage() {
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+
+  const [daily, setDaily] = useState<Record<string, number>>({});
+  const [pomodoros, setPomodoros] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const [tasks, setTasks] = useState({ created: 0, completed: 0 });
+  const [hours, setHours] = useState<number[]>([]);
+
+  useEffect(() => {
+    setMounted(true);
+
+    setDaily(getDailyStudyTime());
+    setPomodoros(getPomodoroCount());
+    setStreak(getStudyStreak());
+    setTasks(getTaskCompletionStats());
+    setHours(getMostProductiveHours());
+  }, []);
+
+  if (!mounted) return null;
+
+  const labels = Object.keys(daily);
+  const values = Object.values(daily);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-950 p-6">
+      <div className="max-w-7xl mx-auto space-y-10">
+
+        {/* Header */}
+        <header className="space-y-3">
+          <button
+            onClick={() => router.push("/study-planner")}
+            className="text-sm text-gray-400 hover:text-green-400 transition flex items-center gap-2 w-fit"
+          >
+            ← Back to Home
+          </button>
+
+          <h1 className="text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-green-400 via-emerald-400 to-cyan-400">
+            Analytics
+          </h1>
+
+          <p className="text-gray-400">
+            Insights into your study habits and productivity
+          </p>
+        </header>
+
+        {/* Stats */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <Stat title="Pomodoro Sessions" value={pomodoros} />
+          <Stat title="Study Streak (days)" value={streak} />
+          <Stat title="Study Days Logged" value={labels.length} />
+          <Stat
+            title="Tasks Completed"
+            value={`${tasks.completed} / ${tasks.created}`}
+          />
+        </div>
+
+        {/* Daily Study Time */}
+        <Section title="📅 Study Time per Day">
+          <div className="h-[320px]">
+            <Bar
+              options={darkChartOptions}
+              data={{
+                labels,
+                datasets: [
+                  {
+                    label: "Minutes Studied",
+                    data: values,
+                    backgroundColor: "rgba(16,185,129,0.7)", // emerald
+                    borderRadius: 8,
+                    barThickness: 32,
+                  },
+                ],
+              }}
+            />
+          </div>
+        </Section>
+
+        {/* Productive Hours */}
+        <Section title="⏰ Most Productive Hours">
+          <div className="h-[320px]">
+            <Line
+              options={darkChartOptions}
+              data={{
+                labels: Array.from({ length: 24 }, (_, i) => `${i}:00`),
+                datasets: [
+                  {
+                    label: "Focus Minutes",
+                    data: hours,
+                    borderColor: "rgba(34,211,238,0.9)", // cyan
+                    backgroundColor: "rgba(34,211,238,0.15)",
+                    tension: 0.4,
+                    fill: true,
+                    pointRadius: 3,
+                    pointHoverRadius: 5,
+                  },
+                ],
+              }}
+            />
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- UI Components ---------- */
+
+function Stat({ title, value }: { title: string; value: string | number }) {
+  return (
+    <div className="bg-gradient-to-br from-gray-800/60 to-gray-900/60 backdrop-blur-sm rounded-2xl p-6 border border-gray-700/50">
+      <p className="text-sm text-gray-400 mb-1">{title}</p>
+      <p className="text-3xl font-bold text-emerald-400">{value}</p>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-gradient-to-br from-gray-800/40 to-gray-900/40 rounded-2xl p-6 border border-gray-700/50">
+      <h2 className="text-lg font-semibold text-white mb-4">{title}</h2>
+      {children}
+    </div>
+  );
+}

--- a/Planora/app/lib/analytics.ts
+++ b/Planora/app/lib/analytics.ts
@@ -1,0 +1,80 @@
+// lib/analytics.ts
+
+// ---------- utils ----------
+const isClient = () => typeof window !== "undefined";
+
+const safeGet = (key: string) => {
+  if (!isClient()) return [];
+  try {
+    return JSON.parse(localStorage.getItem(key) || "[]");
+  } catch {
+    return [];
+  }
+};
+
+// ---------- study sessions ----------
+export function getStudySessions() {
+  return safeGet("studySessions");
+}
+
+export function getPomodoroCount() {
+  return getStudySessions().length;
+}
+
+// ---------- daily totals ----------
+export function getDailyStudyTime() {
+  const sessions = getStudySessions();
+  const daily: Record<string, number> = {};
+
+  sessions.forEach((s: any) => {
+    if (!s.date || !s.duration) return;
+    daily[s.date] = (daily[s.date] || 0) + Number(s.duration);
+  });
+
+  return daily;
+}
+
+// ---------- streak ----------
+export function getStudyStreak() {
+  const days = Object.keys(getDailyStudyTime())
+    .sort()
+    .map(d => new Date(d));
+
+  if (days.length === 0) return 0;
+
+  let streak = 1;
+
+  for (let i = days.length - 1; i > 0; i--) {
+    const diff =
+      (days[i].getTime() - days[i - 1].getTime()) / 86400000;
+
+    if (diff === 1) streak++;
+    else break;
+  }
+
+  return streak;
+}
+
+// ---------- tasks ----------
+export function getTaskCompletionStats() {
+  if (!isClient()) return { created: 0, completed: 0 };
+
+  return {
+    created: Number(localStorage.getItem("tasksCreated") || 0),
+    completed: Number(localStorage.getItem("tasksCompleted") || 0),
+  };
+}
+
+// ---------- productive hours ----------
+export function getMostProductiveHours() {
+  const sessions = getStudySessions();
+  const hours = Array(24).fill(0);
+
+  sessions.forEach((s: any) => {
+    if (!s.date || !s.duration) return;
+    const hour = new Date(s.date).getHours();
+    hours[hour] += Number(s.duration);
+  });
+
+  return hours;
+}

--- a/Planora/app/study-planner/page.tsx
+++ b/Planora/app/study-planner/page.tsx
@@ -75,10 +75,22 @@ export default function StudyPlanner() {
   };
 
   const toggleTask = (id: string) => {
-    setTasks(tasks.map(task => 
-      task.id === id ? { ...task, completed: !task.completed } : task
-    ));
+    setTasks(tasks.map(task => {
+      if (task.id === id) {
+        // ✅ Log task completion ONLY when marking complete
+        if (!task.completed) {
+          localStorage.setItem(
+            "tasksCompleted",
+            String(Number(localStorage.getItem("tasksCompleted") || 0) + 1)
+          );
+        }
+
+        return { ...task, completed: !task.completed };
+      }
+      return task;
+    }));
   };
+
 
   const deleteTask = (id: string) => {
     setTasks(tasks.filter(task => task.id !== id));
@@ -125,6 +137,11 @@ export default function StudyPlanner() {
     router.push('/calender');
   };
 
+  const handleAnalyticsClick = () => {
+    router.push('/analytics');
+  };
+
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-950 p-4 md:p-6">
       <div className="max-w-7xl mx-auto">
@@ -161,6 +178,19 @@ export default function StudyPlanner() {
               Calender
               <span className="group-hover:translate-x-1 transition-transform">→</span>
             </button>
+
+            <button
+              onClick={handleAnalyticsClick}
+              className="group relative bg-gradient-to-r from-emerald-600 to-cyan-600 text-white px-6 py-3 rounded-xl hover:from-emerald-700 hover:to-cyan-700 transition-all duration-300 shadow-xl hover:shadow-cyan-500/20 flex items-center gap-2"
+            >
+              <span className="relative flex h-3 w-3">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-white"></span>
+              </span>
+              Analytics
+              <span className="group-hover:translate-x-1 transition-transform">→</span>
+            </button>
+
           </div>
 
           {/* Stats Cards */}

--- a/Planora/package-lock.json
+++ b/Planora/package-lock.json
@@ -8,8 +8,10 @@
       "name": "planora_v1",
       "version": "0.1.0",
       "dependencies": {
+        "chart.js": "^4.5.1",
         "next": "16.1.1",
         "react": "19.2.3",
+        "react-chartjs-2": "^5.3.1",
         "react-dom": "19.2.3"
       },
       "devDependencies": {
@@ -17,9 +19,11 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "autoprefixer": "^10.4.23",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
-        "tailwindcss": "^4",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.18",
         "typescript": "^5"
       }
     },
@@ -957,6 +961,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2215,6 +2225,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.23",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
+      "integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001760",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2407,6 +2454,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/client-only": {
@@ -3360,6 +3420,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/function-bind": {
@@ -4974,6 +5048,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4982,6 +5058,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -5039,6 +5122,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -5638,7 +5731,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/Planora/package.json
+++ b/Planora/package.json
@@ -9,8 +9,10 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "chart.js": "^4.5.1",
     "next": "16.1.1",
     "react": "19.2.3",
+    "react-chartjs-2": "^5.3.1",
     "react-dom": "19.2.3"
   },
   "devDependencies": {
@@ -18,9 +20,11 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "autoprefixer": "^10.4.23",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
-    "tailwindcss": "^4",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.18",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
This PR introduces a new Analytics page that provides insights into study habits using existing client-side data.
It also fixes an issue where completed tasks were not being logged for analytics.

Analytics Page
- Displays:
   Total Pomodoro sessions
   Study streak (days)
   Total study days
   Tasks completed vs created
- Visualizes data using:
   Bar chart for daily study time
   Line chart for most productive hours
- Uses existing localStorage data (no backend changes)
- Includes a Back to Home navigation link

Bug Fix: Task Completion Logging
- Fixed an issue where completed tasks were not being tracked
- Task completion is now logged only when a task is marked complete
- Prevents double counting when toggling task state

Files Added/Changed
- app/analytics/page.tsx - new analytics dashboard UI
- lib/analytics.tsx - analytics data helpers
- app/study-planner/page.tsx - minimal fix to task completion logging

screenshot
<img width="2837" height="1471" alt="Screenshot 2026-01-28 194621" src="https://github.com/user-attachments/assets/cb0d2bb5-f6c4-452a-b155-f2ea4efa2a65" />

<img width="2720" height="1426" alt="Screenshot 2026-01-28 194634" src="https://github.com/user-attachments/assets/9573b008-07e6-4e72-b544-37fb58775353" />
<img width="2673" height="896" alt="Screenshot 2026-01-28 194640" src="https://github.com/user-attachments/assets/115a3dce-e921-4d1e-af54-bdd31881623d" />
