### PR TITLE
ISSUE #61 | Bug Fixed: Calendar Button

### DIFF
--- a/Planora/app/study-planner/page.tsx
+++ b/Planora/app/study-planner/page.tsx
@@ -134,7 +134,7 @@ export default function StudyPlanner() {
   };
 
   const handleCalenderClick = () => {
-    router.push('/calender');
+    router.push('/calendar');
   };
 
   const handleAnalyticsClick = () => {


### PR DESCRIPTION
This pull request solves the issue of calendar button not working on the study planner page.

The error was caused due to incorrect path written in handleCalenderClick.

Files Modified:
app/study-planner/page.tsx

Screenshot:
<img width="2762" height="956" alt="image" src="https://github.com/user-attachments/assets/8ba3f1db-efb9-44b8-8a08-6e2d12b5c630" />

<img width="2776" height="1442" alt="image" src="https://github.com/user-attachments/assets/b46f0560-c1e4-4406-a29b-85cdc22961c9" />
