### PR TITLE
Implement undo/redo functionality for prompt editing

### DIFF
--- a/PixelPro/src/hooks/useUndoRedo.ts
+++ b/PixelPro/src/hooks/useUndoRedo.ts
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+export function useUndoRedo<T>(initialValue: T) {
+  const [past, setPast] = useState<T[]>([]);
+  const [present, setPresent] = useState<T>(initialValue);
+  const [future, setFuture] = useState<T[]>([]);
+
+  // Set a new value (push current into past)
+  const set = (value: T) => {
+    if (value === present) return;
+
+    setPast((prev) => [...prev, present]);
+    setPresent(value);
+    setFuture([]);
+  };
+
+  // Undo: move one step back
+  const undo = () => {
+    setPast((prevPast) => {
+      if (prevPast.length === 0) return prevPast;
+
+      const previous = prevPast[prevPast.length - 1];
+      setFuture((prevFuture) => [present, ...prevFuture]);
+      setPresent(previous);
+
+      return prevPast.slice(0, prevPast.length - 1);
+    });
+  };
+
+  // Redo: move one step forward
+  const redo = () => {
+    setFuture((prevFuture) => {
+      if (prevFuture.length === 0) return prevFuture;
+
+      const next = prevFuture[0];
+      setPast((prevPast) => [...prevPast, present]);
+      setPresent(next);
+
+      return prevFuture.slice(1);
+    });
+  };
+
+  return {
+    value: present,
+    set,
+    undo,
+    redo,
+    canUndo: past.length > 0,
+    canRedo: future.length > 0,
+  };
+}

--- a/PixelPro/src/pages/GeneratorPage.tsx
+++ b/PixelPro/src/pages/GeneratorPage.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useState } from "react";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { Link } from "react-router-dom";
 import { Sparkles, Code2, ArrowLeft } from "lucide-react";
 import { PromptInput } from "@/components/PromptInput";
@@ -23,7 +24,14 @@ import { toast } from "sonner";
 
 const GeneratorPage = () => {
   // State for the prompt input
-  const [prompt, setPrompt] = useState("");
+  const {
+  value: prompt,
+  set: setPrompt,
+  undo,
+  redo,
+  canUndo,
+  canRedo,
+} = useUndoRedo("");
   
   // State for selected framework
   const [framework, setFramework] = useState<Framework>("react");
@@ -46,7 +54,7 @@ const GeneratorPage = () => {
       toast.error("Please enter a description for your component");
       return;
     }
-
+    setPrompt(prompt);
     setIsLoading(true);
     setGeneratedCode(null);
 
@@ -114,6 +122,25 @@ const GeneratorPage = () => {
                   onChange={setPrompt}
                   disabled={isLoading}
                 />
+                <div className="flex gap-2 mt-2">
+  <Button
+    variant="outline"
+    size="sm"
+    onClick={undo}
+    disabled={!canUndo || isLoading}
+  >
+    Undo
+  </Button>
+
+  <Button
+    variant="outline"
+    size="sm"
+    onClick={redo}
+    disabled={!canRedo || isLoading}
+  >
+    Redo
+  </Button>
+</div>
               </div>
               
               {/* Framework selector */}


### PR DESCRIPTION
**Closes #39**
This PR adds undo and redo support for prompt editing in the Generator page.

**Changes**
- Introduced a reusable useUndoRedo hook to manage prompt history
- Enabled users to undo/redo prompt changes
- Stored prompt state across generations for easy navigation
- Added UI controls for undo and redo actions

**Impact**
Improves usability and gives users better control over prompt iterations during component generation.


https://github.com/user-attachments/assets/58014327-cb8c-4af2-a8b8-026d5ccfbc63

