### PR TITLE
Implement Component History Sidebar with Local Persistence

### DIFF
--- a/PixelPro/src/components/ComponentThumbnail.tsx
+++ b/PixelPro/src/components/ComponentThumbnail.tsx
@@ -1,0 +1,43 @@
+import { Star, Trash2 } from "lucide-react";
+import { ComponentHistoryItem } from "@/hooks/useComponentHistory";
+
+type Props = {
+  item: ComponentHistoryItem;
+  onSelect: () => void;
+  onDelete: () => void;
+  onToggleFavorite: () => void;
+};
+
+export const ComponentThumbnail = ({
+  item,
+  onSelect,
+  onDelete,
+  onToggleFavorite,
+}: Props) => {
+  return (
+    <div
+      className="border border-border rounded-lg p-3 cursor-pointer hover:bg-muted transition"
+      onClick={onSelect}
+    >
+      <div className="flex justify-between items-start mb-2">
+        <span className="font-medium text-sm truncate">{item.name}</span>
+        <div className="flex gap-2">
+          <button onClick={(e) => { e.stopPropagation(); onToggleFavorite(); }}>
+            <Star
+              className={`w-4 h-4 ${
+                item.favorite ? "fill-yellow-400 text-yellow-400" : ""
+              }`}
+            />
+          </button>
+          <button onClick={(e) => { e.stopPropagation(); onDelete(); }}>
+            <Trash2 className="w-4 h-4 text-muted-foreground" />
+          </button>
+        </div>
+      </div>
+
+      <pre className="text-xs bg-background border border-border rounded p-2 overflow-hidden max-h-20">
+        {item.code.slice(0, 120)}...
+      </pre>
+    </div>
+  );
+};

--- a/PixelPro/src/components/HistorySidebar.tsx
+++ b/PixelPro/src/components/HistorySidebar.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { ChevronLeft, Search } from "lucide-react";
+import { ComponentThumbnail } from "./ComponentThumbnail";
+import { useComponentHistory } from "@/hooks/useComponentHistory";
+
+type Props = {
+  onSelectComponent: (code: string) => void;
+};
+
+export const HistorySidebar = ({ onSelectComponent }: Props) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const {
+    history,
+    removeComponent,
+    toggleFavorite,
+  } = useComponentHistory();
+
+  const filtered = history.filter(
+    (item) =>
+      item.prompt.toLowerCase().includes(query.toLowerCase()) ||
+      item.code.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div
+      className={`fixed top-0 right-0 h-full w-80 bg-card border-l border-border shadow-lg
+      transform transition-transform duration-300 z-40
+      ${open ? "translate-x-0" : "translate-x-full"}`}
+    >
+      <button
+        className="absolute -left-10 top-20 bg-card border border-border rounded-l-lg p-2"
+        onClick={() => setOpen(!open)}
+      >
+        <ChevronLeft className={`w-5 h-5 transition ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      <div className="p-4 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Search className="w-4 h-4 text-muted-foreground" />
+          <input
+            className="w-full bg-background border border-border rounded px-2 py-1 text-sm"
+            placeholder="Search history..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="p-4 space-y-3 overflow-y-auto h-full">
+        {filtered.map((item) => (
+          <ComponentThumbnail
+            key={item.id}
+            item={item}
+            onSelect={() => onSelectComponent(item.code)}
+            onDelete={() => removeComponent(item.id)}
+            onToggleFavorite={() => toggleFavorite(item.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/PixelPro/src/hooks/useComponentHistory.ts
+++ b/PixelPro/src/hooks/useComponentHistory.ts
@@ -1,0 +1,58 @@
+import { useLocalStorage } from "./useLocalStorage";
+import { Framework } from "@/components/FrameworkSelector";
+
+export type ComponentHistoryItem = {
+  id: string;
+  name: string;
+  prompt: string;
+  framework: Framework;
+  code: string;
+  favorite: boolean;
+  createdAt: number;
+};
+
+export function useComponentHistory() {
+  const [history, setHistory] = useLocalStorage<ComponentHistoryItem[]>(
+    "pixelpro-component-history",
+    []
+  );
+
+  const addComponent = (item: Omit<ComponentHistoryItem, "id" | "createdAt">) => {
+    setHistory((prev) => [
+      {
+        ...item,
+        id: crypto.randomUUID(),
+        createdAt: Date.now(),
+      },
+      ...prev,
+    ]);
+  };
+
+  const removeComponent = (id: string) => {
+    setHistory((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const renameComponent = (id: string, name: string) => {
+    setHistory((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, name } : item
+      )
+    );
+  };
+
+  const toggleFavorite = (id: string) => {
+    setHistory((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, favorite: !item.favorite } : item
+      )
+    );
+  };
+
+  return {
+    history,
+    addComponent,
+    removeComponent,
+    renameComponent,
+    toggleFavorite,
+  };
+}

--- a/PixelPro/src/hooks/useLocalStorage.ts
+++ b/PixelPro/src/hooks/useLocalStorage.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const stored = window.localStorage.getItem(key);
+      return stored ? JSON.parse(stored) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore write errors
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/PixelPro/src/pages/GeneratorPage.tsx
+++ b/PixelPro/src/pages/GeneratorPage.tsx
@@ -22,6 +22,8 @@ import { Button } from "@/components/ui/button";
 import { generateCode } from "@/services/mockAI";
 import { toast } from "sonner";
 import { MultiFrameworkPreview } from "@/components/MultiFrameworkPreview";
+import { HistorySidebar } from "@/components/HistorySidebar";
+import { useComponentHistory } from "@/hooks/useComponentHistory";
 
 const GeneratorPage = () => {
   // State for the prompt input
@@ -40,7 +42,7 @@ const GeneratorPage = () => {
   // State for generated code output
   const [generatedCode, setGeneratedCode] =
   useState<Record<Framework, string> | null>(null);
-
+  const { addComponent } = useComponentHistory();
   
   // Loading state while generating
   const [isLoading, setIsLoading] = useState(false);
@@ -65,6 +67,14 @@ const GeneratorPage = () => {
       // Call the mock AI service (will be replaced with real API)
       const result = await generateCode(prompt);
       setGeneratedCode(result);
+      addComponent({
+        name: "Generated Component",
+        prompt,
+        framework,
+        code: result[framework],
+        favorite: false,
+    });
+
       toast.success("Component generated successfully!");
     } catch (error) {
       toast.error("Failed to generate component. Please try again.");
@@ -207,6 +217,12 @@ const GeneratorPage = () => {
           </p>
         </div>
       </footer>
+      {/* History Sidebar */}
+      <HistorySidebar
+        onSelectComponent={(code) =>
+          setGeneratedCode({ ...generatedCode!, [framework]: code })
+        }
+      />
     </div>
   );
 };


### PR DESCRIPTION
**Closes #36 – Implement Component History Sidebar**
**What’s added**
This PR introduces a collapsible history sidebar that allows users to manage and revisit previously generated UI components.

 **Key Features**
- Persistent component history using localStorage
- Smooth slide-in / slide-out sidebar animation
- Search through history by prompt or code content
- Mini component thumbnails for quick identification
- Management actions:
  - Favorite components
  - Delete components

**Implementation Details**
- Added reusable hooks for persistence and history tracking
- Modular sidebar and thumbnail components
- Integrated seamlessly into GeneratorPage without layout shifts

**Files Added**
- src/hooks/useLocalStorage.ts
- src/hooks/useComponentHistory.ts
- src/components/HistorySidebar.tsx
- src/components/ComponentThumbnail.tsx

 **Files Modified**
- src/pages/GeneratorPage.tsx

**How to Test**
- Generate a UI component
- Open the history sidebar
- Refresh the page — history persists
- Search, favorite, or delete items from history


https://github.com/user-attachments/assets/729fafaa-363c-4ec3-8532-224fa2339f78



