### PR TITLE
Add full-screen component preview modal

### DIFF
--- a/PixelPro/src/components/ComponentModal.tsx
+++ b/PixelPro/src/components/ComponentModal.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type ComponentModalProps = {
+  open: boolean;
+  code: string;
+  title?: string;
+  onClose: () => void;
+};
+
+export const ComponentModal = ({
+  open,
+  code,
+  title = "Component Preview",
+  onClose,
+}: ComponentModalProps) => {
+  const [size, setSize] = useState({ width: 900, height: 600 });
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center">
+      {/* Modal container */}
+      <div
+        className="bg-background rounded-xl shadow-2xl relative flex flex-col resize overflow-hidden"
+        style={{ width: size.width, height: size.height }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2 cursor-move">
+          <h2 className="text-sm font-semibold">{title}</h2>
+          <Button variant="ghost" size="icon" onClick={onClose}>
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-4">
+          <pre className="text-sm bg-muted rounded-lg p-4 overflow-auto h-full">
+            {code}
+          </pre>
+        </div>
+
+        {/* Resize hint */}
+        <div className="text-xs text-muted-foreground text-center py-1 border-t border-border">
+          Drag edges to resize • Press close to exit
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/PixelPro/src/pages/GeneratorPage.tsx
+++ b/PixelPro/src/pages/GeneratorPage.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { generateCode } from "@/services/mockAI";
 import { toast } from "sonner";
 import { MultiFrameworkPreview } from "@/components/MultiFrameworkPreview";
+import { ComponentModal } from "@/components/ComponentModal";
 
 const GeneratorPage = () => {
   // State for the prompt input
@@ -40,7 +41,7 @@ const GeneratorPage = () => {
   // State for generated code output
   const [generatedCode, setGeneratedCode] =
   useState<Record<Framework, string> | null>(null);
-
+  const [isModalOpen, setIsModalOpen] = useState(false);
   
   // Loading state while generating
   const [isLoading, setIsLoading] = useState(false);
@@ -175,10 +176,12 @@ const GeneratorPage = () => {
                 <Loader />
               ) : generatedCode ? (
                 // Show code preview when code is generated
-               <CodePreview
-  code={generatedCode[framework]}
-  framework={framework}
-/>
+               <div onDoubleClick={() => setIsModalOpen(true)}>
+  <CodePreview
+    code={generatedCode[framework]}
+    framework={framework}
+  />
+</div>
               ) : (
                 // Empty state
                 <div className="flex flex-col items-center justify-center py-16 text-center">
@@ -207,6 +210,13 @@ const GeneratorPage = () => {
           </p>
         </div>
       </footer>
+      {generatedCode && (
+  <ComponentModal
+    open={isModalOpen}
+    code={generatedCode[framework]}
+    onClose={() => setIsModalOpen(false)}
+  />
+)}
     </div>
   );
 };


### PR DESCRIPTION
**Closes #38**
This PR adds a full-screen modal for viewing generated components in detail.

**Features:**
- preview shown on double click 
- Overlay modal with focused component preview
- Intuitive close action
- Resizable layout for better inspection
- Clean UI consistent with existing design

**Files added:**
- src/components/ComponentModal.tsx

**Files modified:**
- src/pages/GeneratorPage.tsx


https://github.com/user-attachments/assets/3591a8af-1440-472f-9204-2dc93d50ff28


