### PR TITLE
Implement line selection and copy functionality

### DIFF
--- a/PixelPro/src/components/CodePreview.tsx
+++ b/PixelPro/src/components/CodePreview.tsx
@@ -9,6 +9,7 @@ import { Check, Copy, Code2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { ExportDropdown }  from "./ExportDropdown"; // [1] Import the new component
+import useKeyboardShortcuts from "@/hooks/useKeyboardShortcuts";
 
 interface CodePreviewProps {
   code: string;
@@ -57,6 +58,10 @@ export const CodePreview = ({ code, framework }: CodePreviewProps) => {
   }
 };
 
+  const clearSelection = () => {
+  setSelectedLines(new Set());
+};
+
 
   const getLanguageLabel = () => {
     switch (framework) {
@@ -92,6 +97,12 @@ const toggleLineSelection = (lineNumber: number) => {
     return updated;
   });
 };
+
+  useKeyboardShortcuts({
+  onGenerate: () => {},
+  onCopy: handleCopy,
+  onClear: clearSelection,
+});
 
   return (
     <div className="animate-fade-in-up">
@@ -136,9 +147,11 @@ const toggleLineSelection = (lineNumber: number) => {
     </span>
   ) : (
     <span className="flex items-center gap-2">
-      <Copy className="w-4 h-4" />
-      Copy
-    </span>
+  <Copy className="w-4 h-4" />
+  Copy
+  <span className="text-xs opacity-60">(Ctrl + C)</span>
+</span>
+
   )}
 </>
 

--- a/PixelPro/src/components/CodePreview.tsx
+++ b/PixelPro/src/components/CodePreview.tsx
@@ -18,7 +18,7 @@ interface CodePreviewProps {
 export const CodePreview = ({ code, framework }: CodePreviewProps) => {
   const [copied, setCopied] = useState(false);
   const [showCopied, setShowCopied] = useState(false);
-
+  const [selectedLines, setSelectedLines] = useState<Set<number>>(new Set());
 
   const handleCopy = async () => {
   try {
@@ -35,6 +35,25 @@ export const CodePreview = ({ code, framework }: CodePreviewProps) => {
     }, 1500);
   } catch (err) {
     toast.error("Failed to copy code");
+  }
+};
+
+  const handleCopySelectedLines = async () => {
+  if (selectedLines.size === 0) {
+    toast.error("No lines selected");
+    return;
+  }
+
+  const selectedCode = Array.from(selectedLines)
+    .sort((a, b) => a - b)
+    .map(i => codeLines[i])
+    .join("\n");
+
+  try {
+    await navigator.clipboard.writeText(selectedCode);
+    toast.success("Selected lines copied!");
+  } catch {
+    toast.error("Failed to copy selected lines");
   }
 };
 
@@ -61,6 +80,19 @@ export const CodePreview = ({ code, framework }: CodePreviewProps) => {
   }
 };
 
+  const codeLines = code.split("\n");
+const toggleLineSelection = (lineNumber: number) => {
+  setSelectedLines(prev => {
+    const updated = new Set(prev);
+    if (updated.has(lineNumber)) {
+      updated.delete(lineNumber);
+    } else {
+      updated.add(lineNumber);
+    }
+    return updated;
+  });
+};
+
   return (
     <div className="animate-fade-in-up">
       <div className="flex items-center justify-between mb-3">
@@ -75,7 +107,15 @@ export const CodePreview = ({ code, framework }: CodePreviewProps) => {
         {/* [2] Grouped Actions: Copy and Export */}
         <div className="flex items-center gap-2">
           <ExportDropdown code={code} framework={framework} /> {/* Added framework prop here */}
-          
+          <Button
+  variant="outline"
+  size="sm"
+  onClick={handleCopySelectedLines}
+  disabled={selectedLines.size === 0}
+>
+  Copy Selected
+</Button>
+
           <Button
             variant="outline"
             size="sm"
@@ -121,16 +161,35 @@ export const CodePreview = ({ code, framework }: CodePreviewProps) => {
         
         <div className="relative">
           <pre className="p-4 overflow-x-auto code-scrollbar max-h-[400px]">
-  <code
-    className={`language-${getPrismLanguage()} text-sm font-mono leading-relaxed`}
-    dangerouslySetInnerHTML={{
-      __html: Prism.highlight(
-        code,
-        Prism.languages[getPrismLanguage()],
-        getPrismLanguage()
-      ),
-    }}
-  />
+  <code className={`language-${getPrismLanguage()} text-sm font-mono`}>
+  {codeLines.map((line, index) => {
+    const highlighted = Prism.highlight(
+      line || " ",
+      Prism.languages[getPrismLanguage()],
+      getPrismLanguage()
+    );
+
+    const isSelected = selectedLines.has(index);
+
+    return (
+      <div
+        key={index}
+        onClick={() => toggleLineSelection(index)}
+        className={`flex cursor-pointer px-2 rounded
+          ${isSelected ? "bg-primary/20" : "hover:bg-secondary/40"}
+        `}
+      >
+        <span className="select-none w-10 text-right pr-4 text-muted-foreground">
+          {index + 1}
+        </span>
+        <span
+          dangerouslySetInnerHTML={{ __html: highlighted || "&nbsp;" }}
+        />
+      </div>
+    );
+  })}
+</code>
+
 </pre>
         </div>
       </div>

--- a/PixelPro/src/hooks/useKeyboardShortcuts.ts
+++ b/PixelPro/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+interface KeyboardShortcutProps {
+  onGenerate: () => void;
+  onCopy: () => void;
+  onClear: () => void;
+}
+
+const useKeyboardShortcuts = ({
+  onGenerate,
+  onCopy,
+  onClear,
+}: KeyboardShortcutProps) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Ctrl + Enter → Generate
+      if (event.ctrlKey && event.key === "Enter") {
+        event.preventDefault();
+        onGenerate();
+      }
+
+      // Ctrl + C → Copy
+      if (event.ctrlKey && event.key.toLowerCase() === "c") {
+        event.preventDefault();
+        onCopy();
+      }
+
+      // Escape → Clear
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClear();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onGenerate, onCopy, onClear]);
+};
+
+export default useKeyboardShortcuts;

--- a/PixelPro/src/pages/GeneratorPage.tsx
+++ b/PixelPro/src/pages/GeneratorPage.tsx
@@ -24,6 +24,7 @@ import { toast } from "sonner";
 import { MultiFrameworkPreview } from "@/components/MultiFrameworkPreview";
 import { HistorySidebar } from "@/components/HistorySidebar";
 import { useComponentHistory } from "@/hooks/useComponentHistory";
+import useKeyboardShortcuts from "@/hooks/useKeyboardShortcuts";
 
 const GeneratorPage = () => {
   // State for the prompt input
@@ -83,6 +84,18 @@ const GeneratorPage = () => {
       setIsLoading(false);
     }
   };
+
+  const handleClear = () => {
+  setPrompt("");
+  setGeneratedCode(null);
+  toast.info("Cleared");
+};
+
+  useKeyboardShortcuts({
+  onGenerate: handleGenerate,
+  onCopy: () => {}, // handled in CodePreview
+  onClear: handleClear,
+});
 
   return (
     <div className="min-h-screen bg-background">
@@ -166,15 +179,17 @@ const GeneratorPage = () => {
               {/* Generate button */}
               <div className="flex items-end">
                 <Button
-                  variant="generate"
-                  size="lg"
-                  className="w-full"
-                  onClick={handleGenerate}
-                  disabled={isLoading || !prompt.trim()}
-                >
-                  <Sparkles className="w-5 h-5" />
-                  {isLoading ? "Generating..." : "Generate Component"}
-                </Button>
+  variant="generate"
+  size="lg"
+  className="w-full"
+  onClick={handleGenerate}
+  disabled={isLoading || !prompt.trim()}
+>
+  <Sparkles className="w-5 h-5" />
+  {isLoading ? "Generating..." : "Generate Component"}
+  <span className="ml-2 text-xs opacity-70">(Ctrl + Enter)</span>
+</Button>
+
               </div>
             </div>
 


### PR DESCRIPTION
**closes #42 & #40**
# 1
Adds line-by-line selection to the CodePreview component with a Copy Selected feature, allowing users to copy only the required lines from generated code.

**Changes**
- Clickable, highlightable code lines
- Multi-line selection support
- New Copy Selected button
- Improved code readability with line numbers


https://github.com/user-attachments/assets/752642a0-2821-440f-99fe-6bdd7bb209a3

# 2
Improves usability and accessibility by adding global keyboard shortcuts across the generator workflow.

**Implemented shortcuts:**
- **Ctrl + Enter** → Generate component
- **Ctrl + C** → Copy generated code
- **Esc** → Clear prompt / clear code line selection


https://github.com/user-attachments/assets/6040b8b0-e2ba-4df3-a8ad-263dd0daf711

